### PR TITLE
Add fbx autodetection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+#vscode
+.vscode/

--- a/aiofreepybox/.gitignore
+++ b/aiofreepybox/.gitignore
@@ -1,3 +1,5 @@
 /__pycache__/
 *.pyc
 app_auth
+.app_auth*
+.db_*

--- a/aiofreepybox/.gitignore
+++ b/aiofreepybox/.gitignore
@@ -1,5 +1,4 @@
 /__pycache__/
 *.pyc
 app_auth
-.app_auth*
-.db_*
+.fbx_*

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -1,22 +1,23 @@
-import aiohttp
 import asyncio
 import base64
 import bz2
+from importlib import import_module
+from importlib import resources
 import ipaddress
 import json
 import logging
+from os import fspath
+from pathlib import Path
 import pkgutil
 import socket
 import ssl
-from importlib import import_module
-from importlib import resources
-from os import fspath
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin
 
-# aiofpbx imports
+import aiohttp
+
 import aiofreepybox
+from aiofreepybox.access import Access
 from aiofreepybox.exceptions import (
     AuthorizationError,
     HttpRequestError,
@@ -24,7 +25,6 @@ from aiofreepybox.exceptions import (
     InvalidTokenError,
     NotOpenError,
 )
-from aiofreepybox.access import Access
 
 # API modules extra parameters
 _API_MODS_PARAMS: Dict[str, Any] = {}  # {"player": {"api_version": "v6"}}
@@ -322,6 +322,7 @@ class Freepybox:
                 else await self._fbx_open_db(uid)
             )
         except NotOpenError:
+            _LOGGER.error(f"Cannot open freebox with uid: {uid}")
             raise
 
         try:
@@ -329,6 +330,7 @@ class Freepybox:
                 uid, Path(_DATA_DIR), self.app_desc, self.timeout
             )
         except AuthorizationError:
+            _LOGGER.error("Authorization error")
             raise
 
         self._fbx_uid = uid
@@ -492,6 +494,7 @@ class Freepybox:
         try:
             self._fbx_ping_port(host, port)
         except ValueError:
+            _LOGGER.error("Cannot open freebox port")
             raise
 
         # Connect session

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -89,7 +89,7 @@ class Freepybox:
             port
             if port != "auto"
             else 80
-            if host != "auto" and port == "auto"
+            if host != "auto"
             else 443
         )
         s = "" if default_port == 80 else "s"

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -284,17 +284,13 @@ class Freepybox:
             raise InvalidTokenError(f"{_DEFAULT_ERR}Invalid application descriptor")
 
         # Get API access
-        if uid is None:
-            uid = ""
-            try:
+        try:
+            if uid is None:
                 uid = await self._fbx_open_disc(host, port)
-            except NotOpenError:
-                raise
-        else:
-            try:
+            else:
                 uid = await self._fbx_open_db(uid)
-            except NotOpenError:
-                raise
+        except NotOpenError:
+            raise
 
         try:
             self._access = await self._get_app_access(

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -79,26 +79,26 @@ class Freepybox:
                 ]
             if host not in default_host_list:
                 default_host = host
-                logger.debug(f'host set to {host}')
+                logger.debug(f'Host set to {host}')
                 if port == 'auto':
                     logger.warning('Port is set to auto, but host is not in default host list, checking port 80')
                     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     result = sock.connect_ex((default_host,80))
                     if result != 0:
-                        raise HttpRequestError('port 80 is closed, cannot detect freebox')
+                        raise HttpRequestError('Port 80 is closed, cannot detect freebox')
             r = await self._session.get(f'http://{default_host}/api_version', timeout=self.timeout)
             resp = await r.json()
             if host == 'auto':
                 host = resp['api_domain']
-                logger.debug(f'host set to {host}')
+                logger.debug(f'Host set to {host}')
             if port == 'auto':
                 port = resp['https_port']
-                logger.debug(f'port set to {port}')
+                logger.debug(f'Port set to {port}')
             server_version = resp['api_version'][:1]
             short_api_version = self.api_version[1:]
             if self.api_version == 'auto':
                 self.api_version = f'v{server_version}'
-                logger.debug(f'api version set to {self.api_version}')
+                logger.debug(f'API version set to {self.api_version}')
             elif server_version > short_api_version:
                 logger.warning(f'Freebox server support a newer api version: v{server_version}, check api_version ({self.api_version})')
             elif server_version < short_api_version:

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -49,10 +49,10 @@ class Freepybox:
         self._access = None
 
     async def open(self, host='auto', port='auto'):
-        '''
+        """
         Open a session to the freebox, get a valid access module
         and instantiate freebox modules
-        '''
+        """
         if not self._is_app_desc_valid(self.app_desc):
             raise InvalidTokenError('Invalid application descriptor')
 
@@ -84,7 +84,7 @@ class Freepybox:
                 if port == 'auto':
                     logger.warning('Port is set to auto, but host is not in default host list, checking port 80')
                     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                    result = sock.connect_ex((default_host,80))
+                    result = sock.connect_ex((default_host, 80))
                     if result != 0:
                         raise HttpRequestError('Port 80 is closed, cannot detect freebox')
             r = await self._session.get(f'http{secure}://{default_host}/api_version', timeout=self.timeout)
@@ -120,9 +120,9 @@ class Freepybox:
         self.nat = Nat(self._access)
 
     async def close(self):
-        '''
+        """
         Close the freebox session
-        '''
+        """
         if self._access is None:
             raise NotOpenError('Freebox is not open')
 
@@ -130,7 +130,7 @@ class Freepybox:
         await self._session.close()
 
     async def get_permissions(self):
-        '''
+        """
         Returns the permissions for this app.
 
         The permissions are returned as a dictionary key->boolean where the
@@ -142,16 +142,16 @@ class Freepybox:
         opened. If they have been changed in the meantime, they may be outdated
         until the session token is refreshed.
         If the session has not been opened yet, returns None.
-        '''
+        """
         if self._access:
             return await self._access.get_permissions()
         else:
             return None
 
     async def _get_freebox_access(self, host, port, api_version, token_file, app_desc, timeout=10):
-        '''
+        """
         Returns an access object used for HTTP requests.
-        '''
+        """
 
         base_url = self._get_base_url(host, port, api_version)
 
@@ -199,7 +199,7 @@ class Freepybox:
         return fbx_access
 
     async def _get_authorization_status(self, base_url, track_id, timeout):
-        '''
+        """
         Get authorization status of the application token
         Returns:
             unknown 	the app_token is invalid or has been revoked
@@ -207,7 +207,7 @@ class Freepybox:
             timeout 	the user did not confirmed the authorization within the given time
             granted 	the app_token is valid and can be used to open a session
             denied 	    the user denied the authorization request
-        '''
+        """
         url = urljoin(base_url, f'login/authorize/{track_id}')
         r = await self._session.get(url, timeout=timeout)
         resp = await r.json()
@@ -260,14 +260,14 @@ class Freepybox:
             return (None, None, None)
 
     def _get_base_url(self, host, port, freebox_api_version):
-        '''
+        """
         Returns base url for HTTPS requests
         :return:
-        '''
+        """
         return f'https://{host}:{port}/api/{freebox_api_version}/'
 
     def _is_app_desc_valid(self, app_desc):
-        '''
+        """
         Check validity of the application descriptor
-        '''
+        """
         return all(k in app_desc for k in ('app_id', 'app_name', 'app_version', 'device_name'))

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -82,9 +82,7 @@ class Freepybox:
         data_dir: Optional[str] = None,
         timeout: Optional[int] = None,
     ) -> None:
-        self.api_version: str = (
-            api_version if api_version is not None else _DEFAULT_API_VERSION
-        )
+        self.api_version: str = api_version or _DEFAULT_API_VERSION
         self.app_desc: Dict[str, str] = app_desc if app_desc is not None else _APP_DESC
         self.data_dir: Path = Path(data_dir) if data_dir is not None else _SELF_DIR
         self.timeout: int = timeout if timeout is not None else _DEFAULT_TIMEOUT

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -70,23 +70,24 @@ class Freepybox:
             self.api_version
             ]
         if 'auto' in detect:
-            default_host = '212.27.38.253'
+            default_host = 'mafreebox.freebox.fr'
             default_host_list = [
                 'auto',
-                'mafreebox.freebox.fr',
-                '192.168.0.254',
+                'freeplayer.freebox.fr',
                 default_host
                 ]
+            secure = 's'
             if host not in default_host_list:
                 default_host = host
                 logger.debug(f'Host set to {host}')
+                secure = ''
                 if port == 'auto':
                     logger.warning('Port is set to auto, but host is not in default host list, checking port 80')
                     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     result = sock.connect_ex((default_host,80))
                     if result != 0:
                         raise HttpRequestError('Port 80 is closed, cannot detect freebox')
-            r = await self._session.get(f'http://{default_host}/api_version', timeout=self.timeout)
+            r = await self._session.get(f'http{secure}://{default_host}/api_version', timeout=self.timeout)
             resp = await r.json()
             if host == 'auto':
                 host = resp['api_domain']
@@ -94,7 +95,7 @@ class Freepybox:
             if port == 'auto':
                 port = resp['https_port']
                 logger.debug(f'Port set to {port}')
-            server_version = resp['api_version'][:1]
+            server_version = resp['api_version'].split('.')[0]
             short_api_version = self.api_version[1:]
             if self.api_version == 'auto':
                 self.api_version = f'v{server_version}'

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -74,10 +74,18 @@ class Freepybox:
             default_host_list = [
                 'auto',
                 'mafreebox.freebox.fr',
+                '192.168.0.254',
                 default_host
                 ]
             if host not in default_host_list:
                 default_host = host
+                logger.debug(f'host set to {host}')
+                if port == 'auto':
+                    logger.warning('Port is set to auto, but host is not in default host list, checking port 80')
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    result = sock.connect_ex((default_host,80))
+                    if result != 0:
+                        raise HttpRequestError('port 80 is closed, cannot detect freebox')
             r = await self._session.get(f'http://{default_host}/api_version', timeout=self.timeout)
             resp = await r.json()
             if host == 'auto':

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -105,6 +105,7 @@ class Freepybox:
 
             server_version = resp['api_version'].split('.')[0]
             short_api_version_target = self.api_version_target[1:]
+            short_api_version = self.api_version[1:]
 
             # Check auto api version
             if self.api_version == 'auto':
@@ -120,10 +121,8 @@ class Freepybox:
             elif self.api_version == 'server':
                 self.api_version = f'v{server_version}'
                 logger.debug(f'API version set to server version {self.api_version}')
-
-            short_api_version = self.api_version[1:]
-
-            if server_version > short_api_version:
+            # Check user api version
+            elif server_version > short_api_version:
                 logger.debug(f'Freebox server supports a newer api version: v{server_version}, check api_version ({self.api_version}) for support.')
             elif server_version < short_api_version:
                 logger.warning(f'Freebox server does not support this version ({self.api_version}), downgrading to v{server_version}.')

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -124,10 +124,11 @@ class Freepybox:
         else:
             if self._access:
                 kwargs: Dict[str, str] = {}
-                api_mod_class = getattr(mod[k], k.capitalize())
                 if k in _API_MODS_PARAMS and isinstance(_API_MODS_PARAMS[k], dict):
                     kwargs = _API_MODS_PARAMS[k]
-                setattr(self, k, api_mod_class(self._access, **kwargs))
+                setattr(
+                    self, k, getattr(mod[k], k.capitalize())(self._access, **kwargs)
+                )
             else:
                 return getattr(mod[k], k.capitalize())
 
@@ -315,10 +316,11 @@ class Freepybox:
 
         # Get API access
         try:
-            if uid is None:
-                uid = await self._fbx_open_disc(host, port)
-            else:
-                uid = await self._fbx_open_db(uid)
+            uid = (
+                await self._fbx_open_disc(host, port)
+                if uid is None
+                else await self._fbx_open_db(uid)
+            )
         except NotOpenError:
             raise
 

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -109,24 +109,24 @@ class Freepybox:
 
             # Check auto api version
             if self.api_version == 'auto':
+                self.api_version = self.api_version_target
                 # Check server version
-                if server_version >= short_api_version_target:
-                    self.api_version = self.api_version_target
-                    logger.debug(f'API version set to target version {self.api_version}')
-                else:
-                    # This should never happen unless time is going backward
-                    self.api_version = f'v{server_version}'
-                    logger.warning(f'Target API version not supported ({self.api_version_target}), downgrading to server version {self.api_version}')
+                if server_version > short_api_version_target:
+                    logger.debug(f'Freebox server supports a newer api version: v{server_version}, check api_version ({self.api_version}) for support.')
             # Check server api version
             elif self.api_version == 'server':
                 self.api_version = f'v{server_version}'
                 logger.debug(f'API version set to server version {self.api_version}')
+                if server_version > short_api_version_target:
+                    logger.warning(f'Using new API version {self.api_version}, results may vary ')
             # Check user api version
-            elif server_version > short_api_version:
-                logger.debug(f'Freebox server supports a newer api version: v{server_version}, check api_version ({self.api_version}) for support.')
+            elif short_api_version < short_api_version_target and int(short_api_version) > 0:
+                logger.warning(f'Using deprecated API version {self.api_version}, results may vary ')
             elif server_version < short_api_version:
-                logger.warning(f'Freebox server does not support this version ({self.api_version}), downgrading to v{server_version}.')
+                logger.warning(f'Freebox server does not support this API version ({self.api_version}), downgrading to v{server_version}.')
                 self.api_version = f'v{server_version}'
+            elif short_api_version != short_api_version_target:
+                logger.warning(f'User defined API version set to {self.api_version}, results may vary')
 
         self._access = await self._get_freebox_access(host, port, self.api_version, self.token_file, self.app_desc, self.timeout)
 

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -62,8 +62,14 @@ class Freepybox:
     This python library is implementing the freebox OS API.
     It handles the authentication process and provides a raw access to the freebox API in an asynchronous manner.
 
-    api_version : "auto", "server" or "v(1-7)"
-        , Default to "auto"
+    app_desc : `dict`
+        , Default to APP_DESC
+    token_file : `str`
+        , Default to TOKEN_FILE
+    api_version : `str`, "server" or "v(1-7)"
+        , Default to _DEFAULT_API_VERSION
+    timeout : `int`
+        , Default to _DEFAULT_TIMEOUT
     """
 
     def __init__(self, app_desc=None, token_file=None, api_version=None, timeout=None):

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -32,11 +32,6 @@ from aiofreepybox.api.rrd import Rrd
 from aiofreepybox.api.upnpav import Upnpav
 from aiofreepybox.api.upnpigd import Upnpigd
 
-# Token file default location
-TOKEN_FILENAME = "app_auth"
-TOKEN_DIR = os.path.dirname(os.path.abspath(__file__))
-TOKEN_FILE = os.path.join(TOKEN_DIR, TOKEN_FILENAME)
-
 # Default application descriptor
 APP_DESC = {
     "app_id": "aiofpbx",
@@ -44,6 +39,20 @@ APP_DESC = {
     "app_version": aiofreepybox.__version__,
     "device_name": socket.gethostname(),
 }
+
+# Token file default location
+TOKEN_FILENAME = "app_auth"
+TOKEN_DIR = os.path.dirname(os.path.abspath(__file__))
+TOKEN_FILE = os.path.join(TOKEN_DIR, TOKEN_FILENAME)
+
+# App defaults
+_DEFAULT_API_VERSION = "v6"
+_DEFAULT_CERT = "freebox_certificates.pem"
+_DEFAULT_HOST = "mafreebox.freebox.fr"
+_DEFAULT_HTTP_PORT = "80"
+_DEFAULT_HTTPS_PORT = "443"
+_DEFAULT_SSL = True
+_DEFAULT_TIMEOUT = 10
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,66 +66,33 @@ class Freepybox:
         , Default to "auto"
     """
 
-    def __init__(
-        self, app_desc=APP_DESC, token_file=TOKEN_FILE, api_version="auto", timeout=10
-    ):
-        self._access = None
-        self.api_version = api_version
-        self.api_version_target = "v6"
-        self.app_desc = app_desc
-        self.fbx_desc = {}
+    def __init__(self, app_desc=None, token_file=None, api_version=None, timeout=None):
+        self.api_version = (
+            api_version if api_version is not None else _DEFAULT_API_VERSION
+        )
+        self.app_desc = app_desc if app_desc is not None else APP_DESC
+        self.fbx_desc = None
         self.fbx_url = ""
-        self.timeout = timeout
-        self.token_file = token_file
+        self.timeout = timeout if timeout is not None else _DEFAULT_TIMEOUT
+        self.token_file = token_file if token_file is not None else TOKEN_FILE
+        self._access = None
+        self._session = None
 
-    async def open(self, host="auto", port="auto"):
+    async def open(self, host=None, port=None):
         """
         Open a session to the freebox, get a valid access module
         and instantiate freebox modules
 
         host : `str`
-            , Default to "auto"
+            , Default to `None`
         port : `str`
-            , Default to "auto"
+            , Default to `None`
         """
+
         if not self._is_app_desc_valid(self.app_desc):
             raise InvalidTokenError("Invalid application descriptor")
 
-        # Detect host, port and API version
-        default_host = host if host != "auto" else "mafreebox.freebox.fr"
-        default_port = port if port != "auto" else 80 if host != "auto" else 443
-        s = "" if default_port == 80 else "s"
-
-        # Checking host and port
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        result = sock.connect_ex((default_host, default_port))
-        if result != 0:
-            raise HttpRequestError(
-                f"Port {default_port} is closed, cannot detect freebox"
-            )
-        sock.close()
-
-        # Session setup
-        cert_path = os.path.join(os.path.dirname(__file__), "freebox_certificates.pem")
-        ssl_ctx = ssl.create_default_context()
-        ssl_ctx.load_verify_locations(cafile=cert_path)
-        conn = aiohttp.TCPConnector(ssl_context=ssl_ctx)
-        self._session = aiohttp.ClientSession(connector=conn)
-        r = await self._session.get(
-            f"http{s}://{default_host}:{default_port}/api_version", timeout=self.timeout
-        )
-        self.fbx_desc = await r.json()
-
-        # Setting host and port
-        host = (
-            self.fbx_desc["api_domain"]
-            if host == "auto" or default_port == 80
-            else default_host
-        )
-        port = self.fbx_desc["https_port"] if port in ["auto", 80] else default_port
-        self.fbx_url = self._get_base_url(host, port)
-
-        self._check_api_version()
+        host, port = await self._check_and_validate_parameters(host, port)
 
         # Get API access
         self._access = await self._get_app_access(
@@ -149,11 +125,77 @@ class Freepybox:
         """
         Close the freebox session
         """
-        if self._access is None:
-            raise NotOpenError("Freebox is not open")
+
+        if self._access is None or self._session.closed:
+            _LOGGER.warning(f"Closing but freebox is not connected")
+            return
 
         await self._access.post("login/logout")
         await self._session.close()
+        await asyncio.sleep(0.250)
+
+    async def discover(self, default_host=None, default_port=None):
+        """
+        Discover a freebox on the network
+        """
+
+        # Setup host and port
+        if default_host is None:
+            default_host = _DEFAULT_HOST
+
+        default_port = (
+            _DEFAULT_HTTPS_PORT
+            if default_port is None and _DEFAULT_SSL
+            else default_port
+            if _DEFAULT_SSL
+            else _DEFAULT_HTTP_PORT
+        )
+        s = "" if default_port == _DEFAULT_HTTP_PORT or not _DEFAULT_SSL else "s"
+
+        # Check session
+        if (
+            self.fbx_desc is not None
+            and self._session is not None
+            and not self._session.closed
+        ):
+            conns = list(self._session._connector._conns.keys())[0]
+            if default_host != conns.host or default_port != conns.port:
+                self.fbx_desc = None
+                await self._session.close()
+                await asyncio.sleep(0.250)
+                return await self.discover(default_host, default_port)
+            else:
+                return self.fbx_desc
+
+        # Try to connect
+        if (
+            self._session is None
+            or not isinstance(self._session, aiohttp.ClientSession)
+            or self._session.closed
+        ):
+
+            # Checking host and port
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            result = sock.connect_ex((default_host, int(default_port)))
+            if result != 0:
+                return None
+            sock.close()
+
+            try:
+                cert_path = os.path.join(os.path.dirname(__file__), _DEFAULT_CERT)
+                ssl_ctx = ssl.create_default_context()
+                ssl_ctx.load_verify_locations(cafile=cert_path)
+                conn = aiohttp.TCPConnector(ssl_context=ssl_ctx)
+                self._session = aiohttp.ClientSession(connector=conn)
+            except aiohttp.client_exceptions.ClientConnectorError or aiohttp.client_exceptions.ClientConnectorCertificateError or ssl.SSLCertVerificationError:
+                return None
+
+        # Found freebox
+        r = await self._session.get(
+            f"http{s}://{default_host}:{default_port}/api_version", timeout=self.timeout
+        )
+        self.fbx_desc = await r.json()
+        return self.fbx_desc
 
     async def get_permissions(self):
         """
@@ -169,46 +211,90 @@ class Freepybox:
         until the session token is refreshed.
         If the session has not been opened yet, returns None.
         """
+
         if self._access:
             return await self._access.get_permissions()
         else:
             return None
 
-    def _check_api_version(self):
-        # Check auto and server API version
-        server_version = self.fbx_desc["api_version"].split(".")[0]
-        short_api_version_target = self.api_version_target[1:]
-        self.api_version = (
-            self.api_version_target
-            if self.api_version == "auto"
-            else f"v{server_version}"
-            if self.api_version == "server"
-            else self.api_version
+    async def _check_and_validate_parameters(self, target_host, target_port):
+        """
+        Validate host and port
+
+        target_host : `str`
+        target_port : `str`
+        """
+
+        # Discover
+        if await self.discover(target_host, target_port) is None:
+            if self._session is not None:
+                await self._session.close()
+                await asyncio.sleep(0.250)
+            raise HttpRequestError(
+                f"Cannot detect freebox on the network, please check your configuration."
+            )
+
+        # Setting host and port
+        host = (
+            self.fbx_desc["api_domain"]
+            if (
+                (target_host is None or target_port == _DEFAULT_HTTP_PORT)
+                or (target_host is not None and target_port is None)
+            )
+            and _DEFAULT_SSL
+            else _DEFAULT_HOST
+            if target_host is None and not _DEFAULT_SSL
+            else target_host
+        )
+        port = (
+            self.fbx_desc["https_port"]
+            if (target_port is None or target_port == _DEFAULT_HTTP_PORT)
+            and _DEFAULT_SSL
+            else target_port
+            if _DEFAULT_SSL
+            else _DEFAULT_HTTP_PORT
         )
 
-        # Check user api version
+        await self.discover(host, port)
+        self._check_api_version()
+        self.fbx_url = self._get_base_url(host, port)
+
+        return host, port
+
+    def _check_api_version(self):
+        """
+        Check api version
+        """
+
+        # Set API version if needed
+        server_version = self.fbx_desc["api_version"].split(".")[0]
+        short_api_version_target = _DEFAULT_API_VERSION[1:]
+        if self.api_version == "server":
+            self.api_version = f"v{server_version}"
+
+        # Check user API version
         short_api_version = self.api_version[1:]
         if (
             short_api_version_target < server_version
             and short_api_version == server_version
         ):
             _LOGGER.warning(
-                f"Using new API version {self.api_version}, results may vary "
+                f"Using new API version {self.api_version}, results may vary."
             )
         elif (
             short_api_version < short_api_version_target and int(short_api_version) > 0
         ):
             _LOGGER.warning(
-                f"Using deprecated API version {self.api_version}, results may vary "
+                f"Using deprecated API version {self.api_version}, results may vary."
             )
-        elif short_api_version > server_version:
+        elif short_api_version > server_version or int(short_api_version) < 1:
             _LOGGER.warning(
-                f"Freebox server does not support this API version ({self.api_version}), downgrading to {self.api_version_target}."
+                f"Freebox server does not support this API version ({self.api_version}), resetting to {_DEFAULT_API_VERSION}."
             )
-            self.api_version = self.api_version_target
+            self.api_version = _DEFAULT_API_VERSION
 
     async def _get_app_access(
-        self, host, port, api_version, token_file, app_desc, timeout=10
+        self, host, port, api_version, token_file, app_desc, timeout=_DEFAULT_TIMEOUT
     ):
         """
         Returns an access object used for HTTP requests.
@@ -217,12 +303,14 @@ class Freepybox:
         base_url = self._get_base_url(host, port, api_version)
 
         # Read stored application token
-        _LOGGER.info("Read application authorization file")
+        _LOGGER.debug("Reading application authorization file.")
         app_token, track_id, file_app_desc = self._readfile_app_token(token_file)
 
         # If no valid token is stored then request a token to freebox api - Only for LAN connection
         if app_token is None or file_app_desc != app_desc:
-            _LOGGER.info("No valid authorization file found")
+            _LOGGER.warning(
+                "No valid authorization file found, requesting authorization."
+            )
 
             # Get application token from the freebox
             app_token, track_id = await self._get_app_token(base_url, app_desc, timeout)
@@ -238,25 +326,25 @@ class Freepybox:
                 # denied status = authorization failed
                 if status == "denied":
                     raise AuthorizationError(
-                        "The app token is invalid or has been revoked"
+                        "The app token is invalid or has been revoked."
                     )
 
                 # Pending status : user must accept the app request on the freebox
                 elif status == "pending":
                     if not out_msg_flag:
                         out_msg_flag = True
-                        print("Please confirm the authentification on the freebox")
+                        print("Please confirm the authentification on the freebox.")
                     await asyncio.sleep(1)
 
                 # timeout = authorization failed
                 elif status == "timeout":
-                    raise AuthorizationError("Authorization timed out")
+                    raise AuthorizationError("Authorization timed out.")
 
-            _LOGGER.info("Application authorization granted")
+            _LOGGER.info("Application authorization granted.")
 
             # Store application token in file
             self._writefile_app_token(app_token, track_id, app_desc, token_file)
-            _LOGGER.info(f"Application token file was generated: {token_file}")
+            _LOGGER.info(f"Application token file was generated: {token_file}.")
 
         # Create and return freebox http access module
         fbx_access = Access(
@@ -269,6 +357,7 @@ class Freepybox:
         Get the application token from the freebox
         Returns (app_token, track_id)
         """
+
         # Get authentification token
         url = urljoin(base_url, "login/authorize/")
         data = json.dumps(app_desc)
@@ -278,7 +367,7 @@ class Freepybox:
         # raise exception if resp.success != True
         if not resp.get("success"):
             raise AuthorizationError(
-                "Authorization failed (APIResponse: {})".format(json.dumps(resp))
+                "Authorization failed (APIResponse: {}).".format(json.dumps(resp))
             )
 
         app_token = resp["result"]["app_token"]
@@ -296,6 +385,7 @@ class Freepybox:
             granted 	the app_token is valid and can be used to open a session
             denied 	    the user denied the authorization request
         """
+
         url = urljoin(base_url, f"login/authorize/{track_id}")
         r = await self._session.get(url, timeout=timeout)
         resp = await r.json()
@@ -303,23 +393,26 @@ class Freepybox:
 
     def _get_base_url(self, host, port, freebox_api_version=None):
         """
-        Returns base url for HTTPS requests
+        Returns base url for HTTP(S) requests
 
         host : `str`
         port : `str`
         freebox_api_version : `str`
             , Default to `None`
         """
+
+        s = "s" if _DEFAULT_SSL else ""
         if freebox_api_version is None:
-            return f"https://{host}:{port}"
+            return f"http{s}://{host}:{port}"
         else:
             abu = self.fbx_desc["api_base_url"]
-            return f"https://{host}:{port}{abu}{freebox_api_version}/"
+            return f"http{s}://{host}:{port}{abu}{freebox_api_version}/"
 
     def _is_app_desc_valid(self, app_desc):
         """
         Check validity of the application descriptor
         """
+
         return all(
             k in app_desc for k in ("app_id", "app_name", "app_version", "device_name")
         )
@@ -329,6 +422,7 @@ class Freepybox:
         Read the application token in the authentication file.
         Returns (app_token, track_id, app_desc)
         """
+
         try:
             with open(file, "r") as f:
                 d = json.load(f)
@@ -348,6 +442,7 @@ class Freepybox:
         """
         Store the application token in g_app_auth_file file
         """
+
         d = {**app_desc, "app_token": app_token, "track_id": track_id}
 
         with open(file, "w") as f:

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -74,7 +74,7 @@ class Freepybox:
             logger.debug('port set to {0}'.format(port))
         if self.api_version == 'auto':
             self.api_version = 'v{0}'.format(resp['api_version'][:1])
-            logger.debug('api version set to {0}'.format(host))
+            logger.debug('api version set to {0}'.format(self.api_version))
         elif resp['api_version'][:1] > self.api_version[1:]:
             logger.warning('Freebox server support a newer api version: v{0}, check api_version ({1})'.format(resp['api_version'][:1], self.api_version))
         elif resp['api_version'][:1] < self.api_version[1:]:

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -68,7 +68,8 @@ _LOGGER = logging.getLogger(__name__)
 class Freepybox:
     """
     This python library is implementing the freebox OS API.
-    It handles the authentication process and provides a raw access to the freebox API in an asynchronous manner.
+    It handles the authentication process and provides a raw access
+    to the freebox API in an asynchronous manner.
 
     app_desc : `dict`
         , Default to _APP_DESC
@@ -190,9 +191,6 @@ class Freepybox:
         except ssl.SSLCertVerificationError as e:
             await self._disc_close_to_return()
             raise HttpRequestError(f"{e}")
-        # Only for testing
-        # except Exception as e:
-        # raise e
 
         if r.content_type != "application/json":
             return await self._disc_close_to_return()
@@ -259,6 +257,7 @@ class Freepybox:
 
     async def _disc_check_session(self, host, port, s):
         """Check discovery session"""
+
         if self.fbx_desc and self._session is not None and not self._session.closed:
             conns = list(self._session._connector._conns.keys())[0]
             if (
@@ -269,6 +268,7 @@ class Freepybox:
                 raise ValueError(self.fbx_desc)
             elif await self._disc_close_to_return() is None:
                 raise ValueError(await self.discover(host, port))
+
         return host, port, s
 
     async def _disc_close_to_return(self):
@@ -279,6 +279,7 @@ class Freepybox:
         if self._session is not None and not self._session.closed:
             await self._session.close()
             await asyncio.sleep(0.250)
+
         return None
 
     async def _disc_connect(self, host, port, s):
@@ -301,7 +302,6 @@ class Freepybox:
             else:
                 conn = aiohttp.TCPConnector()
             self._session = aiohttp.ClientSession(connector=conn)
-
         except ssl.SSLCertVerificationError:
             return await self._disc_close_to_return()
 
@@ -414,8 +414,7 @@ class Freepybox:
                 "Authorization failed (APIResponse: {}).".format(json.dumps(resp))
             )
 
-        app_token = resp["result"]["app_token"]
-        track_id = resp["result"]["track_id"]
+        app_token, track_id = resp["result"]["app_token"], resp["result"]["track_id"]
 
         return app_token, track_id
 
@@ -440,6 +439,7 @@ class Freepybox:
         url = urljoin(base_url, f"login/authorize/{track_id}")
         r = await self._session.get(url, timeout=timeout)
         resp = await r.json()
+
         return resp["result"]["status"]
 
     def _get_base_url(self, host, port, freebox_api_version=None):
@@ -465,7 +465,6 @@ class Freepybox:
 
         app_desc : `dict`
         """
-
         return all(
             k in app_desc for k in ("app_id", "app_name", "app_version", "device_name")
         )
@@ -476,6 +475,7 @@ class Freepybox:
 
         ip_address : `str`
         """
+
         try:
             ipaddress.IPv4Network(ip_address)
             return True
@@ -488,6 +488,7 @@ class Freepybox:
 
         ip_address : `str`
         """
+
         try:
             ipaddress.IPv6Network(ip_address)
             return True
@@ -505,7 +506,6 @@ class Freepybox:
 
             if await self.discover(host, port) is None:
                 raise ValueError
-
         except (ValueError, HttpRequestError):
             unk = _DEFAULT_UNKNOWN
             host, port = (
@@ -520,6 +520,7 @@ class Freepybox:
 
         self._check_api_version()
         self.fbx_url = self._get_base_url(host, port)
+
         return host, port
 
     def _open_setup(self, host, port):
@@ -539,6 +540,7 @@ class Freepybox:
                 _DEFAULT_HOST if host is None else host,
                 _DEFAULT_HTTP_PORT if port is None else port,
             )
+
         return host, port
 
     def _readfile_app_token(self, file):
@@ -561,7 +563,6 @@ class Freepybox:
                     if k in d
                 }
                 return app_token, track_id, app_desc
-
         except FileNotFoundError:
             return None, None, None
 
@@ -576,6 +577,5 @@ class Freepybox:
         """
 
         d = {**app_desc, "app_token": app_token, "track_id": track_id}
-
         with open(file, "w") as f:
             json.dump(d, f)

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -278,7 +278,7 @@ class Freepybox:
         _LOGGER.debug(f"{len(fbx_db)} uid(s) in db")
         return fbx_db
 
-    async def get_permissions(self) -> Optional[dict]:
+    async def get_permissions(self) -> Optional[Dict[str, bool]]:
         """
         Returns the permissions for this app.
 

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -64,8 +64,13 @@ class Freepybox:
         self._session = aiohttp.ClientSession(connector=conn)
 
         # Detect host, port and api_version
-        if host == 'auto' or port == 'auto' or self.api_version == 'auto':
-            r = await self._session.get('http://mafreebox.freebox.fr/api_version', timeout=self.timeout)
+        detect = [host, port, self.api_version]
+        if 'auto' in detect:
+            default_host = '212.27.38.253'
+            host_list = ['auto', 'mafreebox.freebox.fr', default_host]
+            if host not in host_list:
+                default_host = host
+            r = await self._session.get('http://{0}/api_version'.format(default_host), timeout=self.timeout)
             resp = await r.json()
             if host == 'auto':
                 host = resp['api_domain']

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -64,22 +64,23 @@ class Freepybox:
         self._session = aiohttp.ClientSession(connector=conn)
 
         # Detect host, port and api_version
-        r = await self._session.get('http://mafreebox.freebox.fr/api_version', timeout=self.timeout)
-        resp = await r.json()
-        if host == 'auto':
-            host = resp['api_domain']
-            logger.debug('host set to {0}'.format(host))
-        if port == 'auto':
-            port = resp['https_port']
-            logger.debug('port set to {0}'.format(port))
-        if self.api_version == 'auto':
-            self.api_version = 'v{0}'.format(resp['api_version'][:1])
-            logger.debug('api version set to {0}'.format(self.api_version))
-        elif resp['api_version'][:1] > self.api_version[1:]:
-            logger.warning('Freebox server support a newer api version: v{0}, check api_version ({1})'.format(resp['api_version'][:1], self.api_version))
-        elif resp['api_version'][:1] < self.api_version[1:]:
-            logger.warning('Freebox server does not support this version ({0}), downgrading to v{1}'.format(self.api_version, resp['api_version'][:1]))
-            self.api_version = 'v{0}'.format(resp['api_version'][:1])
+        if host == 'auto' or port == 'auto' or self.api_version == 'auto':
+            r = await self._session.get('http://mafreebox.freebox.fr/api_version', timeout=self.timeout)
+            resp = await r.json()
+            if host == 'auto':
+                host = resp['api_domain']
+                logger.debug('host set to {0}'.format(host))
+            if port == 'auto':
+                port = resp['https_port']
+                logger.debug('port set to {0}'.format(port))
+            if self.api_version == 'auto':
+                self.api_version = 'v{0}'.format(resp['api_version'][:1])
+                logger.debug('api version set to {0}'.format(self.api_version))
+            elif resp['api_version'][:1] > self.api_version[1:]:
+                logger.warning('Freebox server support a newer api version: v{0}, check api_version ({1})'.format(resp['api_version'][:1], self.api_version))
+            elif resp['api_version'][:1] < self.api_version[1:]:
+                logger.warning('Freebox server does not support this version ({0}), downgrading to v{1}'.format(self.api_version, resp['api_version'][:1]))
+                self.api_version = 'v{0}'.format(resp['api_version'][:1])
 
         self._access = await self._get_freebox_access(host, port, self.api_version, self.token_file, self.app_desc, self.timeout)
 

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -78,24 +78,24 @@ class Freepybox:
                 ]
             if host not in default_host_list:
                 default_host = host
-            r = await self._session.get('http://{0}/api_version'.format(default_host), timeout=self.timeout)
+            r = await self._session.get(f'http://{default_host}/api_version', timeout=self.timeout)
             resp = await r.json()
             if host == 'auto':
                 host = resp['api_domain']
-                logger.debug('host set to {0}'.format(host))
+                logger.debug(f'host set to {host}')
             if port == 'auto':
                 port = resp['https_port']
-                logger.debug('port set to {0}'.format(port))
+                logger.debug(f'port set to {port}')
             server_version = resp['api_version'][:1]
             short_api_version = self.api_version[1:]
             if self.api_version == 'auto':
-                self.api_version = 'v{0}'.format(server_version)
-                logger.debug('api version set to {0}'.format(self.api_version))
+                self.api_version = f'v{server_version}'
+                logger.debug(f'api version set to {self.api_version}')
             elif server_version > short_api_version:
-                logger.warning('Freebox server support a newer api version: v{0}, check api_version ({1})'.format(server_version, self.api_version))
+                logger.warning(f'Freebox server support a newer api version: v{server_version}, check api_version ({self.api_version})')
             elif server_version < short_api_version:
-                logger.warning('Freebox server does not support this version ({0}), downgrading to v{1}'.format(self.api_version, server_version))
-                self.api_version = 'v{0}'.format(server_version)
+                logger.warning(f'Freebox server does not support this version ({self.api_version}), downgrading to v{server_version}')
+                self.api_version = f'v{server_version}'
 
         self._access = await self._get_freebox_access(host, port, self.api_version, self.token_file, self.app_desc, self.timeout)
 
@@ -182,7 +182,7 @@ class Freepybox:
 
             # Store application token in file
             self._writefile_app_token(app_token, track_id, app_desc, token_file)
-            logger.info('Application token file was generated: {0}'.format(token_file))
+            logger.info(f'Application token file was generated: {token_file}')
 
         # Create freebox http access module
         fbx_access = Access(self._session, base_url, app_token, app_desc['app_id'], timeout)
@@ -199,7 +199,7 @@ class Freepybox:
             granted 	the app_token is valid and can be used to open a session
             denied 	    the user denied the authorization request
         '''
-        url = urljoin(base_url, 'login/authorize/{0}'.format(track_id))
+        url = urljoin(base_url, f'login/authorize/{track_id}')
         r = await self._session.get(url, timeout=timeout)
         resp = await r.json()
         return resp['result']['status']
@@ -217,7 +217,7 @@ class Freepybox:
 
         # raise exception if resp.success != True
         if not resp.get('success'):
-            raise AuthorizationError('Authorization failed (APIResponse: {0})'
+            raise AuthorizationError('Authorization failed (APIResponse: {})'
                                      .format(json.dumps(resp)))
 
         app_token = resp['result']['app_token']
@@ -255,7 +255,7 @@ class Freepybox:
         Returns base url for HTTPS requests
         :return:
         '''
-        return 'https://{0}:{1}/api/{2}/'.format(host, port, freebox_api_version)
+        return f'https://{host}:{port}/api/{freebox_api_version}/'
 
     def _is_app_desc_valid(self, app_desc):
         '''

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -407,13 +407,19 @@ class Freepybox:
         if db is None:
             try:
                 d = await self.discover()
-            except ValueError:
-                raise NotOpenError
+            except ValueError as err:
+                raise NotOpenError(
+                f"{err.args[0]}: Cannot detect freebox for uid: {uid}"
+                ", please check your configuration."
+                )
         else:
             self._fbx_db[uid] = db
             d = await self._fbx_enum_conns(db)
         if uid != d["uid"]:
-            raise NotOpenError
+            raise NotOpenError(
+                f"Cannot detect freebox for uid: {uid}"
+                ", please check your configuration."
+                )
         self._fbx_db[d["uid"]]["conf"]["api_version"] = self._check_api_version(
             self._fbx_db[d["uid"]]["desc"]["api_version"]
         )
@@ -625,12 +631,13 @@ class Freepybox:
             , Default to `True`
         """
 
+        abu = ""
         conn = self._fbx_db[uid]["conn"][(self._fbx_db[uid]["conf"]["cc"])]
         if api:
             abu = self._fbx_db[uid]["desc"]["api_base_url"]
             api_version = self._fbx_db[uid]["conf"]["api_version"]
-            return f"http{conn['s']}://{conn['host']}:{conn['port']}{abu}{api_version}/"
-        return f"http{conn['s']}://{conn['host']}:{conn['port']}"
+            abu =  f"{abu}{api_version}/"
+        return f"http{conn['s']}://{conn['host']}:{conn['port']}{abu}"
 
     def _is_app_desc_valid(self, app_desc: Dict[str, str]) -> bool:
         """

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -39,7 +39,7 @@ from aiofreepybox.api.upnpav import Upnpav
 from aiofreepybox.api.upnpigd import Upnpigd
 
 # Default application descriptor
-from typing import Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 _APP_DESC = {
     "app_id": "aiofpbx",
@@ -404,7 +404,7 @@ class Freepybox:
 
     async def _get_app_token(
         self, base_url: str, app_desc: Dict[str, str], timeout: int = _DEFAULT_TIMEOUT
-    ):
+    ) -> Tuple[str, str]:
         """
         Get the application token from the freebox
 
@@ -435,7 +435,7 @@ class Freepybox:
 
     async def _get_authorization_status(
         self, base_url: str, track_id: str, timeout: int = _DEFAULT_TIMEOUT
-    ):
+    ) -> str:
         """
         Get authorization status of the application token
 
@@ -569,7 +569,7 @@ class Freepybox:
 
         return host, port
 
-    def _readfile_app_token(self, file: str):
+    def _readfile_app_token(self, file: str) -> Tuple[Any, Any, Any]:
         """
         Read the application token in the authentication file.
 
@@ -594,7 +594,7 @@ class Freepybox:
 
     def _writefile_app_token(
         self, app_token: str, track_id: str, app_desc: Dict[str, str], file: str
-    ):
+    ) -> None:
         """
         Store the application token in a _TOKEN_FILE file
 

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -59,7 +59,7 @@ _DEFAULT_HTTP_PORT = "80"
 _DEFAULT_HTTPS_PORT = "443"
 _DEFAULT_SSL = True
 _DEFAULT_TIMEOUT = 10
-_DEFAULT_UKNOWN = "?"
+_DEFAULT_UNKNOWN = "?"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -71,13 +71,13 @@ class Freepybox:
     It handles the authentication process and provides a raw access
     to the freebox API in an asynchronous manner.
 
-    app_desc : `dict`
+    app_desc : `dict` , optional
         , Default to _APP_DESC
-    token_file : `str`
+    token_file : `str` , optional
         , Default to _TOKEN_FILE
-    api_version : `str`, "server" or "v(1-7)"
+    api_version : `str`, "server" or "v(1-7)" , optional
         , Default to _DEFAULT_API_VERSION
-    timeout : `int`
+    timeout : `int` , optional
         , Default to _DEFAULT_TIMEOUT
     """
 
@@ -98,9 +98,9 @@ class Freepybox:
         Open a session to the freebox, get a valid access module
         and instantiate freebox modules
 
-        host : `str`
+        host : `str` , optional
             , Default to `None`
-        port : `str`
+        port : `str` , optional
             , Default to `None`
         """
 
@@ -155,9 +155,9 @@ class Freepybox:
         """
         Discover a freebox on the network
 
-        host : `str`
+        host : `str` , optional
             , Default to None
-        port : `str`
+        port : `str` , optional
             , Default to None
         """
 
@@ -336,7 +336,8 @@ class Freepybox:
         api_version : `str`
         token_file : `str`
         app_desc : `dict`
-        timeout : `int`
+        timeout : `int` , optional
+            , Default to _DEFAULT_TIMEOUT
         """
 
         base_url = self._get_base_url(host, port, api_version)
@@ -397,7 +398,8 @@ class Freepybox:
 
         base_url : `str`
         app_desc : `dict`
-        timeout : `int`
+        timeout : `int` , optional
+            , Default to _DEFAULT_TIMEOUT
 
         Returns app_token, track_id
         """
@@ -426,7 +428,8 @@ class Freepybox:
 
         base_url : `str`
         track_id : `str`
-        timeout : `int`
+        timeout : `int` , optional
+            , Default to _DEFAULT_TIMEOUT
 
         Returns:
             unknown 	the app_token is invalid or has been revoked
@@ -448,7 +451,7 @@ class Freepybox:
 
         host : `str`
         port : `str`
-        freebox_api_version : `str`
+        freebox_api_version : `str` , optional
             , Default to `None`
         """
 

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -151,7 +151,7 @@ class Freepybox:
         elif self._is_ipv4(default_host) and default_port is None:
             default_port = _DEFAULT_HTTP_PORT
         elif self._is_ipv6(default_host):
-            _LOGGER.error(f"IPv6 is not supported")
+            _LOGGER.error(f"{default_host} : IPv6 is not supported")
             return None
 
         default_port = (

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -1,14 +1,12 @@
+import aiohttp
 import asyncio
 import ipaddress
-import os
 import json
 import logging
+import os
 import socket
 import ssl
-import time
 from urllib.parse import urljoin
-
-import aiohttp
 
 import aiofreepybox
 from aiofreepybox.exceptions import *

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -656,13 +656,16 @@ class Freepybox:
             _LOGGER.info(f"Application token file was generated: {tk_file}.")
 
         # Create and return freebox http access module
-        fbx_access = Access(
-            self._session,
-            self._get_db_base_url(uid),
-            app_token,
-            app_desc["app_id"],
-            timeout,
-        )
+        if self._session is None:
+            raise AuthorizationError(f"{_DEFAULT_ERR}Session error")
+        else:
+            fbx_access = Access(
+                self._session,
+                self._get_db_base_url(uid),
+                app_token,
+                app_desc["app_id"],
+                timeout,
+            )
         return fbx_access
 
     async def _get_app_token(

--- a/aiofreepybox/api/__init__.py
+++ b/aiofreepybox/api/__init__.py
@@ -1,4 +1,4 @@
 #-*- coding:utf-8 -*-
+from typing import List
 
-__all__ = []
-
+__all__: List[str] = []

--- a/example.py
+++ b/example.py
@@ -27,11 +27,14 @@ async def demo():
     if fbx.api_version == 'v6':
         # Get a jpg snapshot from a camera
         fbx_cam_jpg = await fbx.home.get_camera_snapshot()
+        fbx_cam_jpg.close()
 
         # Get a TS stream from a camera
         r = await fbx.home.get_camera_stream_m3u8()
         m3u8_obj = m3u8.loads(await r.text())
+        r.close()
         fbx_ts = await fbx.home.get_camera_ts(m3u8_obj.files[0])
+        fbx_ts.close()
 
     # Dump freebox configuration using system API
     # Extract temperature and mac address

--- a/example.py
+++ b/example.py
@@ -9,6 +9,7 @@ import asyncio
 import m3u8
 
 from aiofreepybox import Freepybox
+from aiofreepybox.exceptions import (NotOpenError, AuthorizationError)
 
 
 async def demo():
@@ -22,7 +23,13 @@ async def demo():
     # Connect to the freebox
     # Be ready to authorize the application on the Freebox if you use this
     # example for the first time
-    await fbx.open()
+
+    try:
+        await fbx.open()
+    except NotOpenError as e:
+        print(f"Something went wrong {e}")
+    except AuthorizationError as e:
+        print(str(e))
 
     if fbx.api_version == 'v6':
         # Get a jpg snapshot from a camera

--- a/example.py
+++ b/example.py
@@ -15,12 +15,12 @@ async def demo():
     fbx = Freepybox()
 
     # To find out the HTTPS host and port of your freebox, go to
-    # http://mafreebox.freebox.fr/api_version
+    # http://mafreebox.freebox.fr/api_version or let auto detect do it for you
 
     # Connect to the freebox
     # Be ready to authorize the application on the Freebox if you use this
     # example for the first time
-    await fbx.open(host='abcdefgh.fbxos.fr', port=1234)
+    await fbx.open()
 
     # Dump freebox configuration using system API
     # Extract temperature and mac address


### PR DESCRIPTION
Detect freebox host, port and api_version
cleanup, format, refactor
Support any number of freeboxes
Open by uid
breaking change : token file has been removed, each freebox now has it's own token file indexed by uid
api modules instances are now created only when they're called.
settings can be stored anywhere using the data_dir option.