### PR TITLE
FW API: ajout endpoints + tri

### DIFF
--- a/src/freebox_api/api/fw.py
+++ b/src/freebox_api/api/fw.py
@@ -29,13 +29,13 @@ class Fw:
         """
         return await self._access.post("fw/redir/", port_forwarding_config)
 
-    async def delete_port_forwarding_configuration(self, redir_id):
+    async def delete_port_forwarding_configuration(self, config_id):
         """
         Delete port forwarding configuration
 
         config_id : `int`
         """
-        await self._access.delete(f"fw/redir/{redir_id}")
+        await self._access.delete(f"fw/redir/{config_id}")
 
     async def get_port_forwarding_configuration(self, redir_id):
         """
@@ -59,7 +59,13 @@ class Fw:
             f"fw/redir/{redir_id}", port_forwarding_config
         )
 
-    async def get_incoming_ports_configuration(self):
+    async def get_incoming_port_configuration(self, port_id):
+        """
+        Get incoming ports configuration
+        """
+        return await self._access.get(f"fw/incoming/{port_id}")
+
+    async def get_all_incoming_port_configuration(self):
         """
         Get incoming ports configuration
         """

--- a/src/freebox_api/api/fw.py
+++ b/src/freebox_api/api/fw.py
@@ -19,7 +19,9 @@ class Fw:
 
     dmz_configuration_schema = {"enabled": False, "ip": ""}
 
-    async def create_port_forwarding_configuration(self, port_forwarding_config):
+    async def create_port_forwarding_configuration(
+        self, port_forwarding_config
+    ):
         """
         Create port forwarding configuration
 
@@ -34,6 +36,34 @@ class Fw:
         config_id : `int`
         """
         await self._access.delete(f"fw/redir/{config_id}")
+
+    async def get_port_forwarding_configuration(self, redir_id):
+        """
+        Get a specific port forwarding
+        """
+        return await self._access.get(f"fw/redir/{redir_id}")
+
+    async def get_all_port_forwarding_configuration(self):
+        """
+        Get port forwarding configuration
+        """
+        return await self._access.get("fw/redir/")
+
+    async def edit_port_forwarding_configuration(
+        self, redir_id, port_forwarding_config
+    ):
+        """
+        Update a port forwarding
+        """
+        return await self._access.put(
+            f"fw/redir/{redir_id}", port_forwarding_config
+        )
+
+    async def get_incoming_ports_configuration(self):
+        """
+        Get incoming ports configuration
+        """
+        return await self._access.get("fw/incoming/")
 
     async def edit_incoming_port_configuration(
         self, port_id, incoming_port_configuration_data
@@ -53,18 +83,6 @@ class Fw:
         Get dmz configuration
         """
         return await self._access.get("fw/dmz/")
-
-    async def get_incoming_ports_configuration(self):
-        """
-        Get incoming ports configuration
-        """
-        return await self._access.get("fw/incoming/")
-
-    async def get_port_forwarding_configuration(self):
-        """
-        Get port forwarding configuration
-        """
-        return await self._access.get("fw/redir/")
 
     async def set_dmz_configuration(self, dmz_configuration=None):
         """

--- a/src/freebox_api/api/fw.py
+++ b/src/freebox_api/api/fw.py
@@ -29,13 +29,13 @@ class Fw:
         """
         return await self._access.post("fw/redir/", port_forwarding_config)
 
-    async def delete_port_forwarding_configuration(self, config_id):
+    async def delete_port_forwarding_configuration(self, redir_id):
         """
         Delete port forwarding configuration
 
         config_id : `int`
         """
-        await self._access.delete(f"fw/redir/{config_id}")
+        await self._access.delete(f"fw/redir/{redir_id}")
 
     async def get_port_forwarding_configuration(self, redir_id):
         """

--- a/src/freebox_api/api/fw.py
+++ b/src/freebox_api/api/fw.py
@@ -19,9 +19,7 @@ class Fw:
 
     dmz_configuration_schema = {"enabled": False, "ip": ""}
 
-    async def create_port_forwarding_configuration(
-        self, port_forwarding_config
-    ):
+    async def create_port_forwarding_configuration(self, port_forwarding_config):
         """
         Create port forwarding configuration
 
@@ -55,9 +53,7 @@ class Fw:
         """
         Update a port forwarding
         """
-        return await self._access.put(
-            f"fw/redir/{redir_id}", port_forwarding_config
-        )
+        return await self._access.put(f"fw/redir/{redir_id}", port_forwarding_config)
 
     async def get_incoming_port_configuration(self, port_id):
         """


### PR DESCRIPTION
Changements :
* ⚠️ **BREAKING** `get_port_forwarding_configuration` ➡️  sert maintenant à récup la config d'une règle précise selon `redir_id` 
* ⚠️ **BREAKING** `get_all_port_forwarding_configuration` ➡️ était nommée avant `get_port_forwarding_configuration` (récup de toutes les redirections)
* ⚠️ **BREAKING** `get_incoming_ports_configuration` ➡️ sert maintenant à récup la config d'un port entrant ouvert précis selon `port_id`
* ⚠️ **BREAKING** `get_all_incoming_ports_configuration` ➡️ était nommée avant `get_incoming_ports_configuration` (récup de tous les ports ouverts en entrée)
* `edit_port_forwarding_configuration` ➡️ Edition d'une règle précise selon `redir_id`

Les breakings ne le sont pas dans HA, aucun de ces appels n'est utilisé ! Uniquement dans le cas d'un usage autre de la lib.

Tri des fonctions pour une meilleure lisibilité dans cet ordre si tous présents pour les 3 catégories (redirection, incoming, dmz) : 
* create
* delete
* get
* get_all
* edit
* set