### PR TITLE
Update call.py

### DIFF
--- a/src/freebox_api/api/call.py
+++ b/src/freebox_api/api/call.py
@@ -53,7 +53,7 @@ class Call:
         """
         Mark calls log as read
         """
-        return await self._access.get("call/log/mark_all_as_read")
+        return await self._access.post("call/log/mark_all_as_read")
 
     async def update_call_log(self, log_id, call_entry):
         """


### PR DESCRIPTION
There is an error in the original documentation.
The "mark_all_as_read" function shouldn't be called with a get method, but a post one otherwise we get an error.