### PR TITLE
Fix LAN scheme: LanHost primary_name

### DIFF
--- a/src/freebox_api/api/lan.py
+++ b/src/freebox_api/api/lan.py
@@ -29,7 +29,7 @@ class Lan:
         "other",
     ]
 
-    lan_host_data_schema = {"id": "", "primaryName": "", "hostType": host_type[0]}
+    lan_host_data_schema = {"id": "", "primary_name": "", "hostType": host_type[0]}
 
     wol_schema = {"mac": "", "password": ""}
 


### PR DESCRIPTION
Bonjour,

La clé pour le PrimaryName a été modifié en primary_name (cf https://dev.freebox.fr/sdk/os/lan/#lan-browser).

Merci.