### PR TITLE
Release 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "freebox-api"
-version = "1.0.1"
+version = "1.1.0"
 description = "Provides asynchronous authentication and access to Freebox servers"
 authors = ["stilllman <luc_touraille@yahoo.fr>", "quentame <polletquentin74@me.com>", "HACF <contact@hacf.fr>"]
 license = "GNU GPL v3"


### PR DESCRIPTION
- Libs bump
- Bump Python version to 3.11 #492
- Fix LAN scheme: LanHost primary_name #425 @RithyNicolasTAN
- Add italian iliadbox CA root certificate #437 @alekitto
- Fix several security issues:
  - https://github.com/hacf-fr/freebox-api/security/dependabot/2: #455
  - https://github.com/hacf-fr/freebox-api/security/dependabot/3: #472
  - https://github.com/hacf-fr/freebox-api/security/dependabot/4: #461

