### PR TITLE
Fix doc build & bump build to py3.11

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,9 +3,10 @@ sphinx:
   configuration: docs/conf.py
 formats: all
 python:
-  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - path: .
 build:
-  image: testing
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"


### PR DESCRIPTION
https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

https://github.com/hacf-fr/meteofrance-api/pull/668