### PR TITLE
Fixed add_download_task_from_url

### DIFF
--- a/src/freebox_api/access.py
+++ b/src/freebox_api/access.py
@@ -143,6 +143,7 @@ class Access:
         """
         Send post request and return results
         """
+        data: Optional[str|Any] = None
         if json_transform:
             data = json.dumps(payload) if payload else None
         else:

--- a/src/freebox_api/access.py
+++ b/src/freebox_api/access.py
@@ -138,12 +138,15 @@ class Access:
         return await self._perform_request(self.session.get, end_url)
 
     async def post(
-        self, end_url: str, payload: Optional[Dict[str, Any]] = None
+        self, end_url: str, payload: Optional[Dict[str, Any]] = None, json_transform: bool = True
     ) -> Dict[str, Any]:
         """
         Send post request and return results
         """
-        data = json.dumps(payload) if payload else None
+        if json_transform:
+            data = json.dumps(payload) if payload else None
+        else:
+            data = payload if payload else None
         return await self._perform_request(self.session.post, end_url, data=data)  # type: ignore
 
     async def put(

--- a/src/freebox_api/api/download.py
+++ b/src/freebox_api/api/download.py
@@ -107,9 +107,9 @@ class Download:
         """
         Add download from url
 
-        download_url : `str`
+        download_url : `dict`
         """
-        return await self._access.post("downloads/add/", download_url)
+        return await self._access.post("downloads/add/", download_url, False)
 
     async def add_download_task_from_file(
         self, download_file: Dict[str, Any]


### PR DESCRIPTION
Added an optional parameter to `access.py`'s `post` function, as the `downloads/add/` endpoint's input must be formatted ["using “application/x-www-form-urlencoded” (or “multipart/form-data” for file upload)"](https://dev.freebox.fr/sdk/os/download/#adding-by-url). This allowed me to fix `Download.add_download_task_from_url`, but I have a big hunch that `Download.add_download_task_from_file` could also be affected by this issue.
I also fixed `Download.add_download_task_from_url`'s documentation that previously indicated that its parameter was supposed to be a string even though the typing indicated in the function declaration is of a `Dict[str, Any]`. I would also suggest referencing the `download_url_schema` variable in `Download.add_download_task_from_url`'s documentation.

PS : Sorry for the typo in the commit name on my side !

Tests results (tell me if that's not what you're looking for) : 
```
nox > Session coverage was successful.
nox > Ran multiple sessions:
nox > * pre-commit: skipped
nox > * safety: skipped
nox > * mypy-3.11: skipped
nox > * mypy-3.10: success
nox > * mypy-3.9: skipped
nox > * mypy-3.8: skipped
nox > * tests-3.11: skipped
nox > * tests-3.10: success
nox > * tests-3.9: skipped
nox > * tests-3.8: skipped
nox > * typeguard-3.11: skipped
nox > * typeguard-3.10: success
nox > * typeguard-3.9: skipped
nox > * typeguard-3.8: skipped
nox > * xdoctest-3.11: skipped
nox > * xdoctest-3.10: success
nox > * xdoctest-3.9: skipped
nox > * xdoctest-3.8: skipped
nox > * docs-build: skipped
nox > * coverage: success
```