### PR TITLE
Bump actions/[upload|download]-artifact from v3 to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,14 +88,15 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: "actions/upload-artifact@v3.1.3"
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.python-version }}-${{ matrix.os }}
           path: ".coverage.*"
+          include-hidden-files: true
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/_build
@@ -128,9 +129,10 @@ jobs:
           nox --version
 
       - name: Download coverage data
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          pattern: coverage-data-*
+          merge-multiple: true
 
       - name: Combine coverage data and display human readable report
         run: |


### PR DESCRIPTION
Closes:
- #687 
- #651 

`upload-artifact` v4 release note: https://github.com/actions/upload-artifact/releases/tag/v4.0.0

Migration from v3 to v4: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md from https://github.com/actions/upload-artifact/issues/472

As https://github.com/hacf-fr/meteofrance-api/pull/774