### PR TITLE
Disable ssl VERIFY_X509_STRICT with self-signed certificate DNS

### DIFF
--- a/src/freebox_api/aiofreepybox.py
+++ b/src/freebox_api/aiofreepybox.py
@@ -118,6 +118,8 @@ class Freepybox:
         cert_path = os.path.join(os.path.dirname(__file__), "freebox_certificates.pem")
         ssl_ctx = ssl.create_default_context()
         ssl_ctx.load_verify_locations(cafile=cert_path)
+        # Disable strict validating introduced in Python 3.13, which doesn't work with default Freebox certificates
+        ssl_ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
 
         conn = TCPConnector(ssl_context=ssl_ctx)
         self._session = ClientSession(connector=conn)

--- a/src/freebox_api/aiofreepybox.py
+++ b/src/freebox_api/aiofreepybox.py
@@ -118,9 +118,10 @@ class Freepybox:
         cert_path = os.path.join(os.path.dirname(__file__), "freebox_certificates.pem")
         ssl_ctx = ssl.create_default_context()
         ssl_ctx.load_verify_locations(cafile=cert_path)
-        # Disable strict validating introduced in Python 3.13, which doesn't
-        # work with default Freebox certificates
-        ssl_ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+        if ".fbxos.fr" in host or "mafreebox.freebox.fr" in host:
+            # Disable strict validating introduced in Python 3.13, which doesn't
+            # work with default Freebox certificates
+            ssl_ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
 
         conn = TCPConnector(ssl_context=ssl_ctx)
         self._session = ClientSession(connector=conn)

--- a/src/freebox_api/aiofreepybox.py
+++ b/src/freebox_api/aiofreepybox.py
@@ -118,7 +118,8 @@ class Freepybox:
         cert_path = os.path.join(os.path.dirname(__file__), "freebox_certificates.pem")
         ssl_ctx = ssl.create_default_context()
         ssl_ctx.load_verify_locations(cafile=cert_path)
-        # Disable strict validating introduced in Python 3.13, which doesn't work with default Freebox certificates
+        # Disable strict validating introduced in Python 3.13, which doesn't
+        # work with default Freebox certificates
         ssl_ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
 
         conn = TCPConnector(ssl_context=ssl_ctx)


### PR DESCRIPTION
The new flag enforced in Python 3.13 with
https://github.com/python/cpython/issues/107361 doesn't work with the semi broken Freebox self signed certificates.

It should fix https://github.com/home-assistant/core/issues/132333

Fixes #734