### PR TITLE
Tchao Bye bye the token file

### DIFF
--- a/src/freebox_api/__init__.py
+++ b/src/freebox_api/__init__.py
@@ -7,9 +7,9 @@ Freebox API documentation : http://dev.freebox.fr/sdk/os/
 # importlib.metadata available from Python 3.8 use importlib_metadata for
 # earlier versions.
 try:
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
 except ImportError:  # pragma: no cover
-    from importlib_metadata import version, PackageNotFoundError  # type: ignore
+    from importlib_metadata import PackageNotFoundError, version  # type: ignore
 
 
 try:
@@ -17,6 +17,7 @@ try:
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
 
-from freebox_api.aiofreepybox import Freepybox
+from .aiofreepybox import Freepybox
+from .exceptions import FreeboxException
 
-__all__ = ["Freepybox"]
+__all__ = ["Freepybox", "FreeboxException"]

--- a/src/freebox_api/access.py
+++ b/src/freebox_api/access.py
@@ -8,9 +8,9 @@ from urllib.parse import urljoin
 
 from aiohttp import ClientSession
 
-from freebox_api.exceptions import AuthorizationError
-from freebox_api.exceptions import HttpRequestError
-from freebox_api.exceptions import InsufficientPermissionsError
+from .exceptions import AuthorizationError
+from .exceptions import HttpRequestError
+from .exceptions import InsufficientPermissionsError
 
 logger = logging.getLogger(__name__)
 

--- a/src/freebox_api/aiofreepybox.py
+++ b/src/freebox_api/aiofreepybox.py
@@ -4,47 +4,39 @@ import logging
 import os
 import socket
 import ssl
-from typing import Any
-from typing import Dict
-from typing import Optional
-from typing import Tuple
-from typing import Union
+from typing import Any, Dict, Optional, Tuple, Union
 from urllib.parse import urljoin
 
-from aiohttp import ClientSession, ClientTimeout
-from aiohttp import TCPConnector
+from aiohttp import ClientSession, ClientTimeout, TCPConnector
 
-import freebox_api
-from freebox_api.access import Access
-from freebox_api.api.airmedia import Airmedia
-from freebox_api.api.call import Call
-from freebox_api.api.connection import Connection
-from freebox_api.api.dhcp import Dhcp
-from freebox_api.api.download import Download
-from freebox_api.api.freeplug import Freeplug
-from freebox_api.api.fs import Fs
-from freebox_api.api.ftp import Ftp
-from freebox_api.api.fw import Fw
-from freebox_api.api.home import Home
-from freebox_api.api.lan import Lan
-from freebox_api.api.lcd import Lcd
-from freebox_api.api.netshare import Netshare
-from freebox_api.api.notifications import Notifications
-from freebox_api.api.parental import Parental
-from freebox_api.api.phone import Phone
-from freebox_api.api.player import Player
-from freebox_api.api.remote import Remote
-from freebox_api.api.rrd import Rrd
-from freebox_api.api.storage import Storage
-from freebox_api.api.switch import Switch
-from freebox_api.api.system import System
-from freebox_api.api.tv import Tv
-from freebox_api.api.upnpav import Upnpav
-from freebox_api.api.upnpigd import Upnpigd
-from freebox_api.api.wifi import Wifi
-from freebox_api.exceptions import AuthorizationError
-from freebox_api.exceptions import InvalidTokenError
-from freebox_api.exceptions import NotOpenError
+from .access import Access
+from .api.airmedia import Airmedia
+from .api.call import Call
+from .api.connection import Connection
+from .api.dhcp import Dhcp
+from .api.download import Download
+from .api.freeplug import Freeplug
+from .api.fs import Fs
+from .api.ftp import Ftp
+from .api.fw import Fw
+from .api.home import Home
+from .api.lan import Lan
+from .api.lcd import Lcd
+from .api.netshare import Netshare
+from .api.notifications import Notifications
+from .api.parental import Parental
+from .api.phone import Phone
+from .api.player import Player
+from .api.remote import Remote
+from .api.rrd import Rrd
+from .api.storage import Storage
+from .api.switch import Switch
+from .api.system import System
+from .api.tv import Tv
+from .api.upnpav import Upnpav
+from .api.upnpigd import Upnpigd
+from .api.wifi import Wifi
+from .exceptions import AuthorizationError, InvalidTokenError, NotOpenError
 
 # Token file default location
 DEFAULT_TOKEN_FILENAME = "app_auth"  # noqa S105
@@ -55,7 +47,7 @@ DEFAULT_TOKEN_FILE = os.path.join(DEFAULT_TOKEN_DIRECTORY, DEFAULT_TOKEN_FILENAM
 DEFAULT_APP_DESC: Dict[str, str] = {
     "app_id": "aiofpbx",
     "app_name": "freebox-api",
-    "app_version": freebox_api.__version__,
+    "app_version": 0,
     "device_name": socket.gethostname(),
 }
 

--- a/src/freebox_api/api/airmedia.py
+++ b/src/freebox_api/api/airmedia.py
@@ -8,7 +8,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Airmedia:

--- a/src/freebox_api/api/call.py
+++ b/src/freebox_api/api/call.py
@@ -5,7 +5,7 @@ https://dev.freebox.fr/sdk/os/call/
 
 from typing import Dict
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Call:

--- a/src/freebox_api/api/connection.py
+++ b/src/freebox_api/api/connection.py
@@ -3,7 +3,7 @@ Connection API.
 https://dev.freebox.fr/sdk/os/connection/
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Connection:

--- a/src/freebox_api/api/dhcp.py
+++ b/src/freebox_api/api/dhcp.py
@@ -6,7 +6,7 @@ https://dev.freebox.fr/sdk/os/dhcp/
 import logging
 from typing import Dict
 
-from freebox_api.access import Access
+from ..access import Access
 
 logger = logging.getLogger(__name__)
 

--- a/src/freebox_api/api/download.py
+++ b/src/freebox_api/api/download.py
@@ -15,7 +15,7 @@ from typing import Any, TypedDict, Union, List
 from typing import Dict
 from typing import Optional
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class _DownloadAddURL(TypedDict, total=False):

--- a/src/freebox_api/api/freeplug.py
+++ b/src/freebox_api/api/freeplug.py
@@ -3,7 +3,7 @@ Freeplug API.
 https://dev.freebox.fr/sdk/os/freeplug/
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Freeplug:

--- a/src/freebox_api/api/fs.py
+++ b/src/freebox_api/api/fs.py
@@ -8,8 +8,8 @@ import logging
 import os
 from typing import Dict
 
-import freebox_api.exceptions
-from freebox_api.access import Access
+from ..access import Access
+from ..exceptions import HttpRequestError
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ class Fs:
         try:
             await self.get_file_info(os.path.join(self._path, path))
             return True
-        except freebox_api.exceptions.HttpRequestError:
+        except HttpRequestError:
             logger.debug("%s path does not exist", os.path.join(self._path, path))
             return False
 

--- a/src/freebox_api/api/ftp.py
+++ b/src/freebox_api/api/ftp.py
@@ -3,7 +3,7 @@ FTP API.
 https://dev.freebox.fr/sdk/os/ftp/
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Ftp:

--- a/src/freebox_api/api/fw.py
+++ b/src/freebox_api/api/fw.py
@@ -5,7 +5,7 @@ https://dev.freebox.fr/sdk/os/nat/#port-forwarding
 
 from typing import Dict
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Fw:

--- a/src/freebox_api/api/home.py
+++ b/src/freebox_api/api/home.py
@@ -5,7 +5,7 @@ No public documentation available yet.
 
 from typing import Dict
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 # Home structure : adapter > node > endpoint

--- a/src/freebox_api/api/lan.py
+++ b/src/freebox_api/api/lan.py
@@ -3,7 +3,7 @@ LAN API.
 https://dev.freebox.fr/sdk/os/lan/
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Lan:

--- a/src/freebox_api/api/lcd.py
+++ b/src/freebox_api/api/lcd.py
@@ -3,7 +3,7 @@ LCD API.
 https://dev.freebox.fr/sdk/os/lcd/
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Lcd:

--- a/src/freebox_api/api/netshare.py
+++ b/src/freebox_api/api/netshare.py
@@ -3,7 +3,7 @@ Network Share API.
 https://dev.freebox.fr/sdk/os/network_share/
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Netshare:

--- a/src/freebox_api/api/notifications.py
+++ b/src/freebox_api/api/notifications.py
@@ -5,7 +5,7 @@ No public documentation available yet.
 
 from typing import Dict
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Notifications:

--- a/src/freebox_api/api/parental.py
+++ b/src/freebox_api/api/parental.py
@@ -5,7 +5,7 @@ https://dev.freebox.fr/sdk/os/parental/
 
 from typing import Dict
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Parental:

--- a/src/freebox_api/api/phone.py
+++ b/src/freebox_api/api/phone.py
@@ -3,7 +3,7 @@ Phone API.
 No public documentation available yet.
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Phone:

--- a/src/freebox_api/api/player.py
+++ b/src/freebox_api/api/player.py
@@ -8,7 +8,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from freebox_api.access import Access
+from ..access import Access
 
 _DEFAULT_PLAYER_API_VERSION = "v6"
 

--- a/src/freebox_api/api/remote.py
+++ b/src/freebox_api/api/remote.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 from aiohttp import ClientTimeout, ServerDisconnectedError
 
-from freebox_api.access import Access
+from ..access import Access
 
 _PL_LOCAL = "Freebox-Player.local"
 _PL_HOST = "freeboxhd"

--- a/src/freebox_api/api/rrd.py
+++ b/src/freebox_api/api/rrd.py
@@ -5,7 +5,7 @@ https://dev.freebox.fr/sdk/os/rrd/
 
 import time
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Rrd:

--- a/src/freebox_api/api/storage.py
+++ b/src/freebox_api/api/storage.py
@@ -3,7 +3,7 @@ Storage API [UNSTABLE].
 https://dev.freebox.fr/sdk/os/storage/
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Storage:

--- a/src/freebox_api/api/switch.py
+++ b/src/freebox_api/api/switch.py
@@ -3,7 +3,7 @@ Switch API.
 https://dev.freebox.fr/sdk/os/switch/
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Switch:

--- a/src/freebox_api/api/system.py
+++ b/src/freebox_api/api/system.py
@@ -3,7 +3,7 @@ System API.
 https://dev.freebox.fr/sdk/os/system/
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class System:

--- a/src/freebox_api/api/tv.py
+++ b/src/freebox_api/api/tv.py
@@ -7,7 +7,7 @@ https://dev.freebox.fr/sdk/os/pvr/
 import time
 from typing import Dict
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Tv:

--- a/src/freebox_api/api/upnpav.py
+++ b/src/freebox_api/api/upnpav.py
@@ -3,7 +3,7 @@ UPnP AV API.
 https://dev.freebox.fr/sdk/os/upnpav/
 """
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Upnpav:

--- a/src/freebox_api/api/upnpigd.py
+++ b/src/freebox_api/api/upnpigd.py
@@ -5,7 +5,7 @@ https://dev.freebox.fr/sdk/os/igd/
 
 from typing import Dict
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Upnpigd:

--- a/src/freebox_api/api/wifi.py
+++ b/src/freebox_api/api/wifi.py
@@ -5,7 +5,7 @@ https://dev.freebox.fr/sdk/os/wifi/
 
 from typing import Dict
 
-from freebox_api.access import Access
+from ..access import Access
 
 
 class Wifi:

--- a/src/freebox_api/exceptions.py
+++ b/src/freebox_api/exceptions.py
@@ -1,23 +1,23 @@
-class InvalidTokenError(Exception):
+class FreeboxException(Exception):
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
 
 
-class NotOpenError(Exception):
-    def __init__(self, *args, **kwargs):
-        Exception.__init__(self, *args, **kwargs)
+class InvalidTokenError(FreeboxException):
+    """Invalid Token Error."""
 
 
-class AuthorizationError(Exception):
-    def __init__(self, *args, **kwargs):
-        Exception.__init__(self, *args, **kwargs)
+class NotOpenError(FreeboxException):
+    """Not Open Error."""
 
 
-class HttpRequestError(Exception):
-    def __init__(self, *args, **kwargs):
-        Exception.__init__(self, *args, **kwargs)
+class AuthorizationError(FreeboxException):
+    """Authorization Error."""
+
+
+class HttpRequestError(FreeboxException):
+    """HTTP Request Error."""
 
 
 class InsufficientPermissionsError(HttpRequestError):
-    def __init__(self, *args, **kwargs):
-        HttpRequestError.__init__(self, *args, **kwargs)
+    """Insufficient Permissions Error."""


### PR DESCRIPTION
I am the author of the livebox and bouygue api and I propose this redesign, which consists of deleting the token file
You will first have to pass the parameters directly when instantiating the class.
Then make a call to register_app to retrieve the app_token
Once this is done, make a call to the open method and pass the token.

An advantage: the register_app function allows you to retrieve the app_token and possibly save it somewhere, for example in HomeAssistant directly in the config_entry.

All the parameters of the old file can be passed when instantiating the class.

Example:
    fbx = Freepybox()
    app_token = await fbx.register_app()
    await fbx.open(app_token)

I took the opportunity to add the option to use HTTPS or not as well as the verification or not of the certificate.

