### PR TITLE
Fix blocking operations in asyncio warnings

### DIFF
--- a/src/freebox_api/aiofreepybox.py
+++ b/src/freebox_api/aiofreepybox.py
@@ -5,6 +5,7 @@ from os import path
 from os import PathLike
 import socket
 import ssl
+from functools import partial
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -120,7 +121,9 @@ class Freepybox:
             raise InvalidTokenError("Invalid application descriptor")
 
         cert_path = path.join(path.dirname(__file__), "freebox_certificates.pem")
-        ssl_ctx = ssl.create_default_context()
+        ssl_ctx = await asyncio.get_running_loop().run_in_executor(
+            None, partial(ssl.create_default_context, cafile=cert_path)
+        )
         ssl_ctx.load_verify_locations(cafile=cert_path)
         # Disable strict validation introduced in Python 3.13, which doesn't
         # work with Freebox/iliadbox self-signed gateway certificates
@@ -203,10 +206,11 @@ class Freepybox:
         """
 
         base_url: str = self._get_base_url(host, port, api_version)
+        loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         # Read stored application token
         logger.info("Read application authorization file")
-        app_token, track_id, file_app_desc = self._readfile_app_token(token_file)
+        app_token, track_id, file_app_desc = await loop.run_in_executor(None, self._readfile_app_token, token_file)
 
         # If no valid token is stored then request a token to freebox api -
         # Only for LAN connection
@@ -244,7 +248,7 @@ class Freepybox:
             logger.info("Application authorization granted")
 
             # Store application token in file
-            self._writefile_app_token(app_token, track_id, app_desc, token_file)
+            await loop.run_in_executor(None, self._writefile_app_token, app_token, track_id, app_desc, token_file)
             logger.info("Application token file was generated: %s", token_file)
 
         # Create freebox http access module


### PR DESCRIPTION
Since HomeAssistant 2024.6, there are warnings about `open` calls in the main thread.

`Detected blocking call to open inside the event loop by integration 'freebox' at homeassistant/components/freebox/__init__.py, line 26: await api.open(entry.data[CONF_HOST], entry.data[CONF_PORT]) (offender: /usr/local/lib/python3.12/site-packages/freebox_api/aiofreepybox.py, line 255: with open(file, "r") as f:), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+freebox%22 Traceback (most recent call last): File "<frozen runpy>", line 198, in _run_module_as_main File "<frozen runpy>", line 88, in _run_code File "/usr/src/homeassistant/homeassistant/__main__.py", line 223, in <module> sys.exit(main()) File "/usr/src/homeassistant/homeassistant/__main__.py", line 209, in main exit_code = runner.run(runtime_conf) File "/usr/src/homeassistant/homeassistant/runner.py", line 190, in run return loop.run_until_complete(setup_and_run_hass(runtime_config)) File "/usr/local/lib/python3.12/asyncio/base_events.py", line 672, in run_until_complete self.run_forever() File "/usr/local/lib/python3.12/asyncio/base_events.py", line 639, in run_forever self._run_once() File "/usr/local/lib/python3.12/asyncio/base_events.py", line 1988, in _run_once handle._run() File "/usr/local/lib/python3.12/asyncio/events.py", line 88, in _run self._context.run(self._callback, *self._args) File "/usr/src/homeassistant/homeassistant/setup.py", line 165, in async_setup_component result = await _async_setup_component(hass, domain, config) File "/usr/src/homeassistant/homeassistant/setup.py", line 447, in _async_setup_component await asyncio.gather( File "/usr/src/homeassistant/homeassistant/setup.py", line 449, in <genexpr> create_eager_task( File "/usr/src/homeassistant/homeassistant/util/async_.py", line 37, in create_eager_task return Task(coro, loop=loop, name=name, eager_start=True) File "/usr/src/homeassistant/homeassistant/config_entries.py", line 742, in async_setup_locked await self.async_setup(hass, integration=integration) File "/usr/src/homeassistant/homeassistant/config_entries.py", line 594, in async_setup result = await component.async_setup_entry(hass, self) File "/usr/src/homeassistant/homeassistant/components/freebox/__init__.py", line 26, in async_setup_entry await api.open(entry.data[CONF_HOST], entry.data[CONF_PORT])`

It is well documented : [here](https://developers.home-assistant.io/docs/asyncio_blocking_operations/)

This PR fix that.

Has been tested in HomeAssistant.