### PR TITLE
Avoid blocking I/O in Freepybox.open() async path

### DIFF
--- a/src/freebox_api/aiofreepybox.py
+++ b/src/freebox_api/aiofreepybox.py
@@ -215,9 +215,11 @@ class Freepybox:
 
         base_url: str = self._get_base_url(host, port, api_version)
 
-        # Read stored application token
+        # Read stored application token, in an executor thread to avoid blocking I/O.
         logger.info("Read application authorization file")
-        app_token, track_id, file_app_desc = self._readfile_app_token(token_file)
+        app_token, track_id, file_app_desc = await asyncio.to_thread(
+            self._readfile_app_token, token_file
+        )
 
         # If no valid token is stored then request a token to freebox api -
         # Only for LAN connection
@@ -254,8 +256,10 @@ class Freepybox:
 
             logger.info("Application authorization granted")
 
-            # Store application token in file
-            self._writefile_app_token(app_token, track_id, app_desc, token_file)
+            # Store application token in file, in an executor thread to avoid blocking I/O.
+            await asyncio.to_thread(
+                self._writefile_app_token, app_token, track_id, app_desc, token_file
+            )
             logger.info("Application token file was generated: %s", token_file)
 
         # Create freebox http access module


### PR DESCRIPTION
Cette PR déplace les opérations bloquantes hors de la boucle async via `asyncio.to_thread` :
- le chargement des certificats SSL (`load_default_certs`, `load_verify_locations`)
- les I/O du fichier d'autorisation d'app (`_readfile_app_token`, `_writefile_app_token`)

Je l’ai testée dans Home Assistant, où plusieurs warnings apparaissaient `(MainThread) [homeassistant.util.loop] Detected blocking call to...`. Avec ces changements, les warnings disparaissent et l’intégration reste pleinement fonctionnelle.

Fixes: https://github.com/hacf-fr/freebox-api/issues/726
Closes: https://github.com/hacf-fr/freebox-api/pull/799 (duplicates)
Related: https://github.com/home-assistant/core/issues/159206
Related: https://github.com/home-assistant/core/pull/143071
Related: https://github.com/home-assistant/core/issues/143069
